### PR TITLE
launch不用指定设备信息

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,50 +2,13 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Chrome",
+            "name": "adb_kit",
             "request": "launch",
             "type": "dart",
-            "deviceId": "chrome",
             "args": [
                 "--web-renderer",
                 "html"
             ]
-        },
-        {
-            "name": "Linux",
-            "request": "launch",
-            "type": "dart",
-            "deviceId": "linux"
-        },
-        {
-            "name": "Mac Desktop",
-            "request": "launch",
-            "type": "dart",
-            "deviceId": "macos"
-        },
-        {
-            "name": "Windows Desktop",
-            "request": "launch",
-            "type": "dart",
-            "deviceId": "windows"
-        },
-        {
-            "name": "小米14",
-            "request": "launch",
-            "type": "dart",
-            "deviceId": "23127PN0CC"
-        },
-        {
-            "name": "魅族21",
-            "request": "launch",
-            "type": "dart",
-            "deviceId": "MEIZU 21"
-        },
-        {
-            "name": "小米平板6s",
-            "request": "launch",
-            "type": "dart",
-            "deviceId": "24018RPACC"
         },
     ]
 }


### PR DESCRIPTION
可以直接在vscode右下角选择设备， 或者在flutter插件页面选择设备，之后点运行直接就是该设备运行， web启动参数可以保留， 不影响其他设备运行，
<img width="2032" alt="截屏2024-11-24 17 49 54" src="https://github.com/user-attachments/assets/373f99dd-e495-4ccf-8dc2-6aaaa072bf97">
